### PR TITLE
show url protocol when APP_HOST is set

### DIFF
--- a/console/app_serve.go
+++ b/console/app_serve.go
@@ -83,7 +83,7 @@ func (s AppServe) getListenAddr(app inter.App) string {
 
 func (s AppServe) getHumanAddr(app inter.App) interface{} {
 	if s.getHostAddr(app) != "" {
-		return s.getHostAddr(app) + ":" + s.getPortAddr(app)
+		return "http://" + s.getHostAddr(app) + ":" + s.getPortAddr(app)
 	}
 	return "http://localhost:" + s.getPortAddr(app)
 }


### PR DESCRIPTION
Previously, full url would not show when running app:serve if APP_HOST was set. This patch fixes the behavour to always show a clickable URL.

Before
```
go run main.go app:serve
Starting Confetti server: http://localhost:8080

APP_HOST=127.0.0.1 go run main.go app:serve
Starting Confetti server: 127.0.0.1:8080
```

After
```
APP_HOST=127.0.0.1 go run main.go app:serve
Starting Confetti server: http://127.0.0.1:8080
```