### PR TITLE
Add route:list command

### DIFF
--- a/console/route_list.go
+++ b/console/route_list.go
@@ -1,0 +1,66 @@
+package console
+
+import (
+	"path"
+	"reflect"
+	"runtime"
+	"strings"
+
+	"github.com/confetti-framework/contract/inter"
+	"github.com/jedib0t/go-pretty/v6/table"
+)
+
+// RouteListCommand to give you an example of what a command might look like.
+type RouteListCommand struct {
+}
+
+func (e RouteListCommand) Name() string {
+	return "route:list"
+}
+
+func (e RouteListCommand) Description() string {
+	return "Displays a list of all registered routes"
+}
+
+// Handle contains the logic of the command
+func (e RouteListCommand) Handle(c inter.Cli) inter.ExitCode {
+	t := c.Table()
+
+	var routes inter.RouteCollection
+	list, err := c.App().MakeE("routes")
+
+	if err != nil {
+		c.Error("Could not list routes: %s", err)
+		return inter.Failure
+	}
+
+	routes = list.(inter.RouteCollection)
+
+	t.AppendHeader(table.Row{"\x1b[33mMethod\x1b[0m", "\x1b[33mUri\x1b[0m", "\x1b[33mController\x1b[0m", "\x1b[33mName\x1b[0m"})
+
+	for _, route := range routes.All() {
+		controller := route.Controller()
+		controllerName := runtime.FuncForPC(reflect.ValueOf(controller).Pointer()).Name()
+
+		t.AppendRow(table.Row{
+			route.Method(),
+			getCleanRouteUri(route),
+			controllerName,
+			route.Name(),
+		})
+	}
+
+	t.Render()
+
+	return inter.Success
+}
+
+func getCleanRouteUri(route inter.Route) string {
+	uri := route.Uri()
+
+	for _, prefix := range route.RouteOptions().Prefixes() {
+		uri = path.Join(prefix, uri)
+	}
+
+	return strings.Replace(uri, "{allow_slash:\\/?}", "", 1)
+}

--- a/test/console/route_list_test.go
+++ b/test/console/route_list_test.go
@@ -1,0 +1,55 @@
+package console
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/confetti-framework/contract/inter"
+	"github.com/confetti-framework/foundation/console"
+	"github.com/confetti-framework/foundation/http/routing"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_route_list_without_routes_errors(t *testing.T) {
+	writer, app := setUp()
+	var writerErr bytes.Buffer
+
+	app.Bind("config.App.OsArgs", []interface{}{"/main", "route:list"})
+
+	code := console.Kernel{
+		App:       app,
+		Writer:    &writer,
+		WriterErr: &writerErr,
+		Commands:  []inter.Command{console.RouteListCommand{}},
+	}.Handle()
+
+	require.Equal(t, inter.Failure, code)
+	require.Contains(t, writerErr.String(), "Could not list routes: get instance 'routes' from container: key 'routes': can not found value")
+}
+
+func storeUsers(request inter.Request) inter.Response { return nil }
+
+func Test_route_list_shows_routes(t *testing.T) {
+	writer, app := setUp()
+	var writerErr bytes.Buffer
+
+	app.Bind("config.App.OsArgs", []interface{}{"/main", "route:list"})
+	app.Bind("routes", routing.NewRouteCollection(routing.Group(
+		routing.Get("/", func(request inter.Request) inter.Response { return nil }),
+		routing.Post("/users", storeUsers).Name("users.store"),
+	).Prefix("/api")))
+
+	code := console.Kernel{
+		App:       app,
+		Writer:    &writer,
+		WriterErr: &writerErr,
+		Commands:  []inter.Command{console.RouteListCommand{}},
+	}.Handle()
+
+	require.Equal(t, inter.Success, code)
+	result := TrimDoubleSpaces(writer.String())
+	require.Contains(t, result, "\x1b[33mMETHOD\x1b[0m \x1b[33mURI\x1b[0m \x1b[33mCONTROLLER\x1b[0m \x1b[33mNAME\x1b[0m")
+	require.Contains(t, result, "GET /api github.com/confetti-framework/foundation/test/console.Test_route_list_shows_routes.func1")
+	require.Contains(t, result, "HEAD /api github.com/confetti-framework/foundation/test/console.Test_route_list_shows_routes.func1")
+	require.Contains(t, result, "POST /api/users github.com/confetti-framework/foundation/test/console.storeUsers users.store")
+}


### PR DESCRIPTION
This PR adds the `route:list` command that lists all available routes (registered in the `routes` collection on the app container).

## Screenshots

![image](https://user-images.githubusercontent.com/28510368/153750654-8c104694-d082-47c6-9404-77bb5846fee0.png)
