### PR TITLE
Run application middlewares on routing errors

### DIFF
--- a/test/lifecycle/middleware_test.go
+++ b/test/lifecycle/middleware_test.go
@@ -1,13 +1,15 @@
 package lifecycle
 
 import (
+	"testing"
+
 	"github.com/confetti-framework/contract/inter"
 	"github.com/confetti-framework/foundation"
 	"github.com/confetti-framework/foundation/http"
 	"github.com/confetti-framework/foundation/http/middleware"
 	"github.com/confetti-framework/foundation/http/outcome"
+	"github.com/confetti-framework/foundation/http/routing"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_middleware_with_app_from_response(t *testing.T) {
@@ -40,6 +42,22 @@ func Test_middleware_with_app_with_response_in_middleware(t *testing.T) {
 	require.NotNil(t, response.App())
 }
 
+func Test_middleware_called_for_404_route(t *testing.T) {
+	var calls int
+
+	app := foundation.NewApp()
+	app.Bind("response_decorators", []inter.ResponseDecorator{})
+
+	routes := routing.NewRouteCollection()
+	routes.Middleware(countingMiddeware{&calls})
+	app.Bind("routes", routes)
+
+	request := http.NewRequest(http.Options{App: app, Url: "/hello_world"})
+	http.NewRouter(app).DispatchToRoute(request)
+
+	require.Equal(t, 1, calls)
+}
+
 type checkAppRequiredInMiddleware struct{}
 
 func (c checkAppRequiredInMiddleware) Handle(request inter.Request, next inter.Next) inter.Response {
@@ -61,4 +79,13 @@ type middlewareWithResponse struct{}
 
 func (m middlewareWithResponse) Handle(request inter.Request, next inter.Next) inter.Response {
 	return outcome.Html("test")
+}
+
+type countingMiddeware struct {
+	calls *int
+}
+
+func (c countingMiddeware) Handle(request inter.Request, next inter.Next) inter.Response {
+	*c.calls++
+	return next(request)
 }


### PR DESCRIPTION
If a request is made to an URI which doesn’t resolve to a route,
Confetti will currently not execute a middleware. This makes it
impossible to add behavior for handling these soft errors gracefully or
log the request.

Therefore, this makes application middlewares run on routing errors by
storing the middlewares on the RouteCollection and setting them when
creating an error route.